### PR TITLE
[dex] override mpc oneshot to es-la locale

### DIFF
--- a/src/mangaplus/override_options.json
+++ b/src/mangaplus/override_options.json
@@ -43,7 +43,9 @@
         "2000924": ["2008509"],
         "2000925": ["2008510"]
     },
-    "custom_language": {},
+    "custom_language": {
+        "200159": "es-la"
+    },
     "num2words": [
         "one",
         "two",


### PR DESCRIPTION
Ref: https://github.com/ArdaxHz/publoader-extensions/pull/250#issuecomment-2989885217

See: 
Locale here: https://mangadex.org/title/ffc5cbba-7f61-4925-9d3b-dfd8d435ee58/verdugo
MPC page here: https://medibang.com/mpc/titles/wa2503050012488270017978876/
Author's selected locale and region here: https://medibang.com/mpc/authors/17978876/
MangaPlus page here: https://mangaplus.shueisha.co.jp/titles/200159