### PR TITLE
Mark expired M+ chapters unavailable + drop 3-day bodge filter (#399)

### DIFF
--- a/src/mangaplus/mangaplus.py
+++ b/src/mangaplus/mangaplus.py
@@ -7,7 +7,7 @@ import string
 import traceback
 import uuid
 from copy import deepcopy
-from datetime import datetime, time, timezone, timedelta
+from datetime import datetime, time, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Union
 
@@ -62,6 +62,11 @@ class Extension:
         self.manga_id_map_filename = "manga_id_map.json"
         self.override_options_filename = "override_options.json"
         self.extension_dirpath = extension_dirpath
+
+        # Force expired MangaPlus chapters to be marked unavailable rather than
+        # hard-deleted (preserves comment threads / reading history). Matches
+        # publoader's REMOVAL_MODE_UNAVAILABLE; overrides the global toggle.
+        self.chapter_removal_mode = "unavailable"
 
         self.fetch_all_chapters = False
         self._posted_chapters_ids: List[str] = []
@@ -471,10 +476,8 @@ class Extension:
 
     async def _chapter_updates(self, mangas: list):
         """Get the updated chapters from each manga."""
-        # for now, an updated chapter should've been uploaded in the past 3 days
         time_epoch_now = datetime.now()
-        time_epoch_three_days_ago = datetime.now() - timedelta(days = 3)
-        
+
         for manga in mangas:
             manga_response = await self._fetch_title_data(manga_id=manga)
             if not manga_response:
@@ -506,10 +509,7 @@ class Extension:
                 for chapter in normalised_chapters
                 if str(chapter.chapter_id) not in self._posted_chapters_ids
                 and chapter.chapter_expire >= time_epoch_now
-                and chapter.chapter_timestamp >= time_epoch_three_days_ago
             ]
-            # TODO: time_epoch_three_days_ago, as may be evident, is a bodge
-            # consider toggling an unavailable chapter or something (preserves comment threads)
 
             if updated_chapters:
                 logger.info(f"MangaPlus newly updated chapters: {updated_chapters}")


### PR DESCRIPTION
Fixes #399.

### Background
After #366 broke expired-chapter handling (a `datetime - int` crash, since fixed in #386), a residual `chapter_timestamp >= time_epoch_three_days_ago` filter was left behind in `_chapter_updates`. Its own `TODO` flagged it as a "bodge" and pointed at marking chapters unavailable to preserve comment threads — which is exactly what the issue discussion converged on. publoader's mark-unavailable pipeline now exists and is already the default removal mode, so this wires M+ up to it and removes the bodge.

### Changes
- **Pin `chapter_removal_mode = "unavailable"`** on the `Extension` (matches publoader's `REMOVAL_MODE_UNAVAILABLE`). Expired chapters are now marked unavailable — preserving comments / reading history — instead of hard-deleted, regardless of the global toggle.
- **Remove the 3-day `chapter_timestamp` filter** (and the now-unused `timedelta` import). It narrowed the update set to chapters started within the last 3 days, which could suppress legitimately-still-valid chapters; chapter selection now relies on `chapter_expire >= now` plus the posted-ids check.

### Notes / caveat
`chapter_expire` falls back to `datetime.fromtimestamp(1)` (1970) when `endTimeStamp` is absent, so such chapters are still excluded from upload by `chapter_expire >= now`. Behaviour unchanged today; flagging in case upload selection is ever loosened.

Validated: `ast.parse` + `pyflakes` clean (no `timedelta`/`three_days` residue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)