### PR TITLE
Let the database turn the page check on, and fit the sweep in the job's wall clock

### DIFF
--- a/src/mangaplus/src/api.d.ts
+++ b/src/mangaplus/src/api.d.ts
@@ -64,6 +64,16 @@ export interface CollectInput {
 
 export interface ExtensionContext {
   readonly manifest: Readonly<Record<string, unknown>>;
+  /**
+   * The extension's configuration as the DATABASE holds it — what the dashboard
+   * edits, rather than what the bundle shipped with.
+   *
+   * Optional because an older runner does not send it, and an absent field must
+   * not be mistaken for an empty configuration. The two are not merged for you:
+   * how the database's copy relates to the bundled one is the extension's
+   * decision to make explicitly.
+   */
+  readonly overrideOptions?: Readonly<Record<string, unknown>>;
   /** External manga id -> MangaDex title id, DB-authoritative. */
   readonly mangaIdMap: ReadonlyMap<string, string>;
   /** The only sanctioned network primitive; enforces manifest allowed_hosts. */

--- a/src/mangaplus/src/index.ts
+++ b/src/mangaplus/src/index.ts
@@ -74,11 +74,21 @@ const TITLE_CONCURRENCY = 4;
  */
 const VIEWER_CONCURRENCY = 6;
 /**
- * Hard ceiling on viewer calls in one run. Reaching it leaves the remaining
- * chapters unjudged, which keeps them — the safe direction — and is logged
- * rather than passed over silently.
+ * Viewer calls one run may spend, sized to fit the job's wall clock.
+ *
+ * The platform throttles every extension request to one per 500ms, so the
+ * budget is a duration in disguise: 2000 calls is about 17 minutes. A clean run
+ * has already spent roughly 9 minutes on its ~1,038 `title_detailV3` calls
+ * before reaching this, and the job is killed at 3600s, so the two together sit
+ * comfortably inside it. The previous ceiling of 20000 was no ceiling at all —
+ * one call per chapter of the catalogue is ~6,300, about 52 minutes of pure
+ * request time, and the job would have been killed mid-sweep.
+ *
+ * Reaching the budget leaves the remaining chapters unjudged, which keeps them:
+ * an unchecked chapter is treated as alive, so a short run under-reports rather
+ * than unpublishing anything, and says so in the log.
  */
-const MAX_VIEWER_CALLS = 20000;
+const MAX_VIEWER_CALLS = 2000;
 /** What `manga_viewer` is asked for; matches what the site itself requests. */
 const VIEWER_PARAMS = { split: "yes", img_quality: "high" } as const;
 
@@ -642,16 +652,41 @@ class MangaPlus implements ExtensionRuntime {
     const verdicts = new Map<string, ChapterAvailability>();
     // `normaliseChapters` emits one entry per MangaDex chapter number, so a
     // `multi_chapters` chapter appears several times under one MangaPlus id.
-    const chapterIds = [...new Set(chapters.map((chapter) => chapter.chapterId))];
+    // First occurrence wins, which keeps the slot of the entry it came from.
+    const bySlot = new Map<string, RawChapter["listSlot"]>();
+    for (const chapter of chapters) {
+      if (!bySlot.has(chapter.chapterId)) bySlot.set(chapter.chapterId, chapter.listSlot);
+    }
+    const chapterIds = [...bySlot.keys()];
     if (chapterIds.length === 0) return { verdicts, trusted: true };
 
-    const capped = chapterIds.length > MAX_VIEWER_CALLS;
-    const toCheck = capped ? chapterIds.slice(0, MAX_VIEWER_CALLS) : chapterIds;
+    // Spend the budget on the likeliest dead chapters first.
+    //
+    // MangaPlus keeps the opening chapters and the most recent ones free, and
+    // everything between them sits in `midChapterList`. Every refusal seen so
+    // far came from `mid` while `first`/`last` served pages. So when the budget
+    // cannot cover the catalogue, checking `mid` first finds far more of the
+    // dead chapters than reading the list in whatever order it arrived — which
+    // would also re-check the same opening chapters on every run and never
+    // reach the middle at all.
+    const rank = (id: string): number => {
+      const slot = bySlot.get(id);
+      return slot === "mid" ? 0 : slot === "last" ? 1 : 2;
+    };
+    const ordered = [...chapterIds].sort((a, b) => rank(a) - rank(b));
+
+    const capped = ordered.length > MAX_VIEWER_CALLS;
+    const toCheck = capped ? ordered.slice(0, MAX_VIEWER_CALLS) : ordered;
     if (capped) {
-      this.ctx.log("Too many chapters to check for pages; the rest are left as-is", {
-        chapters: chapterIds.length,
+      const uncheckedBySlot = { first: 0, mid: 0, last: 0, unknown: 0 };
+      for (const id of ordered.slice(MAX_VIEWER_CALLS)) {
+        uncheckedBySlot[bySlot.get(id) ?? "unknown"] += 1;
+      }
+      this.ctx.log("Ran out of page-check budget; the rest are left as-is and stay published", {
+        chapters: ordered.length,
         checked: toCheck.length,
-        unchecked: chapterIds.length - toCheck.length,
+        unchecked: ordered.length - toCheck.length,
+        uncheckedBySlot,
       });
     }
 

--- a/src/mangaplus/src/index.ts
+++ b/src/mangaplus/src/index.ts
@@ -365,18 +365,47 @@ class MangaPlus implements ExtensionRuntime {
     };
   }
 
+  /**
+   * The bundled configuration, with the database's copy laid over it.
+   *
+   * The bundle is the baseline: `same`, `multi_chapters` and the title-format
+   * overrides are curated alongside the code and change with it. The database
+   * is what an operator can actually edit, so anything set there wins — which
+   * is the only way a setting like `verify_pages` can be turned on for one run
+   * without publishing a new bundle.
+   *
+   * Merged at the top level only. Every option here is a whole value —
+   * a flag, or a map that is replaced wholesale — and a deep merge would make
+   * "remove this entry" impossible to express from the database.
+   */
   private async loadOverrideOptions(): Promise<OverrideOptions> {
+    let bundled: OverrideOptions = {};
     // data_files declares the logical name and the filename; which one
     // dataFile() keys on is the runner's business, so try both.
     for (const name of ["override_options", "override_options.json"]) {
       try {
-        return JSON.parse(await this.ctx.dataFile(name)) as OverrideOptions;
+        bundled = JSON.parse(await this.ctx.dataFile(name)) as OverrideOptions;
+        break;
       } catch {
         continue;
       }
     }
-    this.ctx.log("No readable override_options; continuing without overrides");
-    return {};
+    if (Object.keys(bundled).length === 0) {
+      this.ctx.log("No readable bundled override_options; using the database's copy alone");
+    }
+
+    // Older runners do not send it; an absent field must not blank the bundle.
+    const fromDatabase = (this.ctx.overrideOptions ?? {}) as Partial<OverrideOptions>;
+    const merged = { ...bundled, ...fromDatabase };
+
+    const overridden = Object.keys(fromDatabase);
+    if (overridden.length > 0) {
+      this.ctx.log("Database override_options applied over the bundled copy", {
+        keys: overridden,
+        verifyPages: merged.verify_pages === true,
+      });
+    }
+    return merged;
   }
 
   /**


### PR DESCRIPTION
Two changes, both needed before the dead-chapter sweep can run at all.

## `verify_pages` is now settable from the dashboard (`10342d0`)

It could previously only be changed by publishing a bundle: the extension read its configuration from the copy baked into its own bundle, so a setting an operator edits in the dashboard reached the runner and went no further. That made "check pages for one run, then stop" a release rather than a decision.

The platform now hands the database's copy over as `ctx.overrideOptions` (publoader#64), and the two are combined **here** rather than there, because how they relate is the extension's call. The bundle stays the baseline — `same`, `multi_chapters` and the title-format overrides are curated alongside the code — and anything set in the database wins.

Top level only. Every option is a whole value (a flag, or a map replaced wholesale), and a deep merge would make "remove this entry" impossible to express from the database. An absent `ctx.overrideOptions` means an older runner, not an empty config, so it leaves the bundle alone. The run logs which keys the database overrode, since a setting that changes what gets published should not be invisible in the record of the run that acted on it.

## The page budget now fits the job (`184a7da`)

The ceiling was 20000, which is no ceiling: the catalogue is ~6,300 chapters against a 2 req/s throttle, so a clean run with the check on would spend ~52 minutes on viewer calls plus ~9 on title calls, against a job killed at 3600s. It would have died mid-sweep.

Now 2000 calls (~17 min). Running out is safe by construction — an unchecked chapter is treated as alive, so a short run under-reports rather than unpublishing anything.

Budget alone was not enough: the old code sliced the first N of whatever order the ids arrived in, so every run re-checked the same opening chapters and never reached the middle. The budget is now spent on `midChapterList` first, where every refusal observed so far has come from, and the log names what was left unchecked by slot.

## Why this matters now

With these, the sweep can run **from the server** rather than from a machine MangaPlus has banned. Enable `verify_pages` from the dashboard, trigger a scoped recheck on one title (~9 viewer calls), and read which chapters the run judged dead from its reported `allChapters`. Oshi no Ko is the decisive case: `1013154` sits in `mid`, `1013146`/`1013149`/`1013158` in `first`.

If that holds, dead-chapter detection costs **zero** extra requests thereafter, and the 6,267-chapter sweep becomes unnecessary.

35 tests pass; typecheck clean.
